### PR TITLE
适配非公有站点

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,6 @@ dist
 dist
 temp
 types
+
+
+/download

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -11,6 +11,7 @@ export interface IOptions {
   distDir: string,
   ignoreImg: boolean,
   token: string
+  key?: string
 }
 
 // 不能直接使用 import {version} from '../package.json'
@@ -27,8 +28,9 @@ cli
   .option('-i, --ignoreImg', '忽略图片不下载', {
     default: false
   })
-  .option('-t, --token <token>', '语雀的cookie "_yuque_session"')
-  .action(async (url, options: IOptions) => {
+  .option('-k, --key <key>', '语雀的cookie key， 默认是 "_yuque_session"， 在某些企业版本中 key 不一样')
+  .option('-t, --token <token>', '语雀的cookie key 对应的值')
+  .action(async (url: string, options: IOptions) => {
     try {
       await main(url, options)
     } catch (err) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,10 +20,11 @@ interface IDownloadArticleParams {
   articleTitle: string,
   articleUrl: string,
   ignoreImg: boolean
+  host?: string
 }
 
 /** 下载单篇文章 */
-async function downloadArticle(params: IDownloadArticleParams, progressBar: ProgressBar, token?: string): Promise<boolean> {
+async function downloadArticle(params: IDownloadArticleParams, progressBar: ProgressBar, token: string, key?: string): Promise<boolean> {
   const {
     bookId,
     itemUrl,
@@ -32,14 +33,17 @@ async function downloadArticle(params: IDownloadArticleParams, progressBar: Prog
     uuid,
     articleUrl,
     articleTitle,
-    ignoreImg
+    ignoreImg,
+    host,
   } = params
-
   const { httpStatus, apiUrl, response} = await getDocsMdData({
     articleUrl: itemUrl,
     bookId,
-    token
+    token,
+    host,
+    key,
   })
+
   const contentType = response?.data?.type?.toLocaleLowerCase() as ARTICLE_CONTENT_TYPE
   // 暂时不支持的文档类型
   if ([
@@ -110,6 +114,7 @@ interface IDownloadArticleListParams {
   bookPath: string,
   bookId: number,
   progressBar: ProgressBar,
+  host?: string
   options: IOptions
 }
 async function downloadArticleList(params: IDownloadArticleListParams) {
@@ -121,6 +126,7 @@ async function downloadArticleList(params: IDownloadArticleListParams) {
     bookPath,
     bookId,
     progressBar,
+    host,
     options
   } = params
   let errArticleCount = 0
@@ -196,8 +202,9 @@ async function downloadArticleList(params: IDownloadArticleListParams) {
           uuid: item.uuid,
           articleUrl,
           articleTitle: item.title,
-          ignoreImg: options.ignoreImg
-        }, progressBar, options.token)
+          ignoreImg: options.ignoreImg,
+          host,
+        }, progressBar, options.token, options.key)
       } catch(e) {
         isSuccess = false
         errArticleCount += 1
@@ -239,8 +246,9 @@ async function main(url: string, options: IOptions) {
     tocList,
     bookName,
     bookDesc,
-    bookSlug
-  } = await getKnowledgeBaseInfo(url, options.token)
+    bookSlug,
+    host,
+  } = await getKnowledgeBaseInfo(url, {token: options.token, key: options.key})
   if (!bookId) throw new Error('No found book id')
   if (!tocList || tocList.length === 0) throw new Error('No found toc list')
 
@@ -276,6 +284,7 @@ async function main(url: string, options: IOptions) {
     bookPath,
     bookId,
     progressBar,
+    host,
     options
   })
 


### PR DESCRIPTION
1. 默认的 download 文件夹加入到 .gitignore
2. 命令行增加 key 参数允许指定cookie key（在非公有语雀情况中认证信息的 cookie 不是 _yuque_session）
3. 从知识库信息中取出正确的 api host 替换默认 host，适配私有知识库的情况