### PR TITLE
feat(cli): add export type for options and adjust config param use

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,10 @@
+{
+  "bracketSpacing": true,
+  "jsxSingleQuote": false,
+  "proseWrap": "never",
+  "semi": false,
+  "singleQuote": true,
+  "tabWidth": 2,
+  "trailingComma": "all",
+  "endOfLine": "lf"
+}

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,7 +1,0 @@
-export default {
-  semi: false,
-  endOfLine: 'lf',
-  singleQuote: true,
-  tabWidth: 2,
-  useTabs: false,
-}

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,41 +1,43 @@
 import { env } from 'node:process'
 import axios from 'axios'
 import { randUserAgent } from './utils'
-import { DEFAULT_COOKIE_KEY, DEFAULT_DOMAIN } from './constant'
+import { DEFAULT_DOMAIN } from './constant'
+import { getConfig } from './config'
 
 import type {
   ArticleResponse,
   KnowledgeBase,
-  GetHeaderParams,
   IReqHeader,
   TGetKnowledgeBaseInfo,
-  TGetMdData
+  TGetMdData,
 } from './types'
 import type { AxiosRequestConfig } from 'axios'
 
-function getHeaders(params: GetHeaderParams): IReqHeader {
-  const { key = DEFAULT_COOKIE_KEY, token } = params
+function getHeaders(): IReqHeader {
+  const { key, token, url, ctoken } = getConfig()
   const headers: IReqHeader = {
     'user-agent': randUserAgent({
       browser: 'chrome',
-      device: 'desktop'
-    })
+      device: 'desktop',
+    }),
+    referer: url,
   }
+  if (ctoken) headers['x-csrf-token'] = ctoken
   if (token) headers.cookie = `${key}=${token};`
   return headers
 }
 
-export function genCommonOptions(params: GetHeaderParams): AxiosRequestConfig {
+export function genCommonOptions(): AxiosRequestConfig {
   const config: AxiosRequestConfig = {
-    headers: getHeaders(params),
+    headers: getHeaders(),
     beforeRedirect: (options) => {
       // 语雀免费非企业空间会重定向如: www.yuque.com -> gxr404.yuque.com
       // 此时axios自动重定向并不会带上cookie
       options.headers = {
         ...(options?.headers || {}),
-        ...getHeaders(params)
+        ...getHeaders(),
       }
-    }
+    },
   }
   if (env.NODE_ENV === 'test') {
     config.proxy = false
@@ -43,19 +45,21 @@ export function genCommonOptions(params: GetHeaderParams): AxiosRequestConfig {
   return config
 }
 
-
 /** 获取知识库数据信息 */
-export const getKnowledgeBaseInfo: TGetKnowledgeBaseInfo = (url, headerParams) => {
+export const getKnowledgeBaseInfo: TGetKnowledgeBaseInfo = (url) => {
   const knowledgeBaseReg = /decodeURIComponent\("(.+)"\)\);/m
-  return axios.get<string>(url, genCommonOptions(headerParams))
-    .then(({data = '', status}) => {
+  return axios
+    .get<string>(url, genCommonOptions())
+    .then(({ data = '', status }) => {
       if (status === 200) return data
       return ''
     })
-    .then(html => {
+    .then((html) => {
       const data = knowledgeBaseReg.exec(html) ?? ''
       if (!data[1]) return {}
-      const jsonData: KnowledgeBase.Response = JSON.parse(decodeURIComponent(data[1]))
+      const jsonData: KnowledgeBase.Response = JSON.parse(
+        decodeURIComponent(data[1]),
+      )
       if (!jsonData.book) return {}
       const info = {
         bookId: jsonData.book.id,
@@ -63,20 +67,23 @@ export const getKnowledgeBaseInfo: TGetKnowledgeBaseInfo = (url, headerParams) =
         tocList: jsonData.book.toc || [],
         bookName: jsonData.book.name || '',
         bookDesc: jsonData.book.description || '',
-        host: jsonData.space?.host || DEFAULT_DOMAIN,
-        imageServiceDomains: jsonData.imageServiceDomains || []
+        host: jsonData.defaultSpaceHost || DEFAULT_DOMAIN,
+        imageServiceDomains: jsonData.imageServiceDomains || [],
       }
       return info
-    }).catch((e) => {
+    })
+    .catch((e) => {
       // console.log(e.message)
       const errMsg = e?.message ?? ''
       if (!errMsg) throw new Error('unknown error')
       const netErrInfoList = [
         'getaddrinfo ENOTFOUND',
         'read ECONNRESET',
-        'Client network socket disconnected before secure TLS connection was established'
+        'Client network socket disconnected before secure TLS connection was established',
       ]
-      const isNetError = netErrInfoList.some(netErrMsg => errMsg.startsWith(netErrMsg))
+      const isNetError = netErrInfoList.some((netErrMsg) =>
+        errMsg.startsWith(netErrMsg),
+      )
       if (isNetError) {
         throw new Error('请检查网络(是否正常联网/是否开启了代理软件)')
       }
@@ -84,13 +91,13 @@ export const getKnowledgeBaseInfo: TGetKnowledgeBaseInfo = (url, headerParams) =
     })
 }
 
-
 export const getDocsMdData: TGetMdData = (params, isMd = true) => {
-  const { articleUrl, bookId, token, key, host = DEFAULT_DOMAIN } = params
+  const { articleUrl, bookId } = params
+  const { host } = getConfig()
   let apiUrl = `${host}/api/docs/${articleUrl}`
   const queryParams: any = {
-    'book_id': String(bookId),
-    'merge_dynamic_data': String(false)
+    book_id: String(bookId),
+    merge_dynamic_data: String(false),
     // plain=false
     // linebreak=true
     // anchor=true
@@ -98,13 +105,41 @@ export const getDocsMdData: TGetMdData = (params, isMd = true) => {
   if (isMd) queryParams.mode = 'markdown'
   const query = new URLSearchParams(queryParams).toString()
   apiUrl = `${apiUrl}?${query}`
-  return axios.get<ArticleResponse.RootObject>(apiUrl, genCommonOptions({token, key}))
-    .then(({data, status}) => {
+  return axios
+    .get<ArticleResponse.RootObject>(apiUrl, genCommonOptions())
+    .then(({ data, status }) => {
       const res = {
         apiUrl,
         httpStatus: status,
-        response: data
+        response: data,
       }
       return res
+    })
+}
+
+export const getLakeFileExportUrl = ({
+  id,
+  type,
+}: {
+  id: number
+  type: string
+}) => {
+  const { host } = getConfig()
+  return axios
+    .post(
+      `${host}/api/docs/${id}/export`,
+      {
+        force: 0,
+        type,
+      },
+      {
+        ...genCommonOptions(),
+      },
+    )
+    .then(({ data }) => {
+      return data.data
+    })
+    .catch((e) => {
+      throw new Error(`get file export url fail: ${e}`)
     })
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,3 @@
-
 import { readFileSync } from 'node:fs'
 import { cac } from 'cac'
 import semver from 'semver'
@@ -7,6 +6,7 @@ import { main } from './index'
 import { logger } from './utils'
 import type { ICliOptions } from './types'
 import { runServer } from './server'
+import { setConfig } from './config'
 
 const cli = cac('yuque-dl')
 
@@ -33,15 +33,35 @@ cli
     default: 'download',
   })
   .option('-i, --ignore-img', '忽略图片不下载', {
-    default: false
+    default: false,
   })
-  .option('-k, --key <key>', '语雀的cookie key， 默认是 "_yuque_session"， 在某些企业版本中 key 不一样')
+  .option(
+    '-k, --key <key>',
+    '语雀的cookie key， 默认是 "_yuque_session"， 在某些企业版本中 key 不一样',
+  )
   .option('-t, --token <token>', '语雀的cookie key 对应的值')
   .option('--toc', '是否输出文档toc目录', {
-    default: false
+    default: false,
   })
+  .option('--docExportType', '输出 doc 文档类型， 默认是 md', {
+    default: 'md',
+  })
+  .option('--sheetExportType', '输出 sheet 文档类型， 默认是 lakesheet', {
+    default: 'lakesheet',
+  })
+  .option('--boardExportType', '输出 board 文档类型， 默认是 lakeboard', {
+    default: 'lakeboard',
+  })
+  .option('--tableExportType', '输出 table 文档类型， 默认是 laketable', {
+    default: 'laketable',
+  })
+  .option(
+    '--ctoken',
+    '语雀授权码，用于模拟用户进行导入导出操作，如果需要导出 lake* 类型文件，此参数必传',
+  )
   .action(async (url: string, options: ICliOptions) => {
     try {
+      setConfig({ ...options, url })
       await main(url, options)
       process.exit(0)
     } catch (err) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,29 @@
+import {
+  BoardExportType,
+  DocExportType,
+  IConfig,
+  SheetExportType,
+  TableExportType,
+} from './types'
+
+export const globalConfig: IConfig = {
+  boardExportType: BoardExportType.lakeboard,
+  distDir: 'docs',
+  docExportType: DocExportType.md,
+  ignoreImg: false,
+  key: '',
+  sheetExportType: SheetExportType.lakesheet,
+  tableExportType: TableExportType.laketable,
+  toc: true,
+  token: '',
+  url: '',
+  host: '',
+}
+
+export const setConfig = (config: Partial<IConfig>) => {
+  Object.assign(globalConfig, config)
+}
+
+export const getConfig = () => {
+  return globalConfig
+}

--- a/src/download/attachments.ts
+++ b/src/download/attachments.ts
@@ -13,8 +13,6 @@ interface IDownloadAttachments {
   savePath: string
   attachmentsDir: string
   articleTitle: string
-  token?: string
-  key?: string
 }
 
 interface IAttachmentsItem {
@@ -24,28 +22,22 @@ interface IAttachmentsItem {
   currentFilePath: string
 }
 
-
 export async function downloadAttachments(params: IDownloadAttachments) {
-  const {
-    mdData,
-    savePath,
-    attachmentsDir,
-    articleTitle,
-    token,
-    key
-  } = params
+  const { mdData, savePath, attachmentsDir, articleTitle } = params
 
-  const attachmentsList = (mdData.match(mdUrlReg) || []).filter(item => AttachmentsReg.test(item))
+  const attachmentsList = (mdData.match(mdUrlReg) || []).filter((item) =>
+    AttachmentsReg.test(item),
+  )
   // 无附件
   if (attachmentsList.length === 0) {
     return {
-      mdData
+      mdData,
     }
   }
 
   const spinner = ora({
     text: `下载 "${articleTitle}" 的附件中...`,
-    stream: stdout
+    stream: stdout,
   })
 
   if (env.NODE_ENV !== 'test') {
@@ -55,8 +47,8 @@ export async function downloadAttachments(params: IDownloadAttachments) {
   const attachmentsDirPath = path.resolve(savePath, attachmentsDir)
 
   const attachmentsDataList = attachmentsList
-    .map(item => parseAttachments(item, attachmentsDirPath))
-    .filter(item => item !== false) as IAttachmentsItem[]
+    .map((item) => parseAttachments(item, attachmentsDirPath))
+    .filter((item) => item !== false) as IAttachmentsItem[]
 
   // 创建文件夹
   mkdirSync(attachmentsDirPath, { recursive: true })
@@ -64,16 +56,16 @@ export async function downloadAttachments(params: IDownloadAttachments) {
     return downloadFile({
       fileUrl: item.url,
       savePath: item.currentFilePath,
-      token,
-      key,
-      fileName: item.fileName
+      fileName: item.fileName,
     })
   })
   const downloadFileInfo = await Promise.all(promiseList).finally(spinnerStop)
 
   let resMdData = mdData
-  downloadFileInfo.forEach(info => {
-    const replaceInfo = attachmentsDataList.find(item => item.url === info.fileUrl)
+  downloadFileInfo.forEach((info) => {
+    const replaceInfo = attachmentsDataList.find(
+      (item) => item.url === info.fileUrl,
+    )
     if (replaceInfo) {
       const replaceData = `[附件: ${replaceInfo.fileName}](${attachmentsDir}/${replaceInfo.fileName})`
       resMdData = resMdData.replace(replaceInfo.rawMd, replaceData)
@@ -84,11 +76,14 @@ export async function downloadAttachments(params: IDownloadAttachments) {
     if (spinner) spinner.stop()
   }
   return {
-    mdData: resMdData
+    mdData: resMdData,
   }
 }
 
-function parseAttachments(mdData: string, attachmentsDirPath: string): IAttachmentsItem | false {
+function parseAttachments(
+  mdData: string,
+  attachmentsDirPath: string,
+): IAttachmentsItem | false {
   const [, rawFileName, url] = AttachmentsReg.exec(mdData) || []
   if (!url) return false
   const fileName = rawFileName || url.split('/').at(-1)
@@ -98,6 +93,6 @@ function parseAttachments(mdData: string, attachmentsDirPath: string): IAttachme
     fileName,
     url,
     rawMd: mdData,
-    currentFilePath
+    currentFilePath,
   }
 }

--- a/src/download/common.ts
+++ b/src/download/common.ts
@@ -3,34 +3,64 @@ import { promisify } from 'node:util'
 import { createWriteStream } from 'node:fs'
 import axios from 'axios'
 
-import { genCommonOptions } from '../api'
+import { genCommonOptions, getLakeFileExportUrl } from '../api'
+import { LakeType } from '../types'
 
 interface IDownloadFileParams {
-  fileUrl: string,
-  savePath: string,
-  token?: string
-  key?: string,
+  fileUrl: string
+  savePath: string
   fileName: string
 }
 
 const finished = promisify(stream.finished)
 export async function downloadFile(params: IDownloadFileParams) {
-  const {fileUrl, savePath, token, key, fileName} = params
-  return axios.get(fileUrl, {
-    ...genCommonOptions({token, key}),
-    responseType: 'stream'
-  }).then(async response => {
-    if (response.request?.path?.startsWith('/login')) {
-      throw new Error(`"${fileName}" need token`)
-    } else if (response.status === 200) {
-      const writer = createWriteStream(savePath)
-      response.data?.pipe(writer)
-      return finished(writer)
-        .then(() => ({
+  const { fileUrl, savePath, fileName } = params
+  return axios
+    .get(fileUrl, {
+      ...genCommonOptions(),
+      responseType: 'stream',
+    })
+    .then(async (response) => {
+      if (response.request?.path?.startsWith('/login')) {
+        throw new Error(`"${fileName}" need token`)
+      } else if (response.status === 200) {
+        const writer = createWriteStream(savePath)
+        response.data?.pipe(writer)
+        return finished(writer).then(() => ({
           fileUrl,
-          savePath
+          savePath,
         }))
+      }
+      throw new Error(`response status ${response.status}`)
+    })
+}
+
+type exportLakeFileProps = {
+  id: number
+  type: LakeType
+  articleTitle: string
+  savePath: string
+}
+
+export const exportLakeFile = async ({
+  id,
+  type,
+  articleTitle,
+  savePath,
+}: exportLakeFileProps) => {
+  try {
+    const data = await getLakeFileExportUrl({
+      id,
+      type,
+    })
+    if (data.url) {
+      await downloadFile({
+        fileUrl: data.url,
+        fileName: `${articleTitle}.${type}`,
+        savePath: `${savePath}/${articleTitle}.${type}`,
+      })
     }
-    throw new Error(`response status ${response.status}`)
-  })
+  } catch (e) {
+    throw new Error(`export board Error: ${e}`)
+  }
 }

--- a/src/download/video.ts
+++ b/src/download/video.ts
@@ -7,6 +7,7 @@ import axios from 'axios'
 import { genCommonOptions } from '../api'
 import { getAst, getLinkList, ILinkItem, toMd } from '../parse/ast'
 import { downloadFile } from './common'
+import { globalConfig } from '../config'
 
 const audioReg = /name="audio" value="data:(.*?audioId.*?)".*?><\/card>/gm
 
@@ -16,38 +17,29 @@ interface IDownloadVideo {
   savePath: string
   attachmentsDir: string
   articleTitle: string
-  token?: string
-  key?: string
 }
 
 export async function downloadVideo(params: IDownloadVideo) {
-  const {
-    mdData,
-    htmlData,
-    savePath,
-    attachmentsDir,
-    articleTitle,
-    token,
-    key
-  } = params
+  const { mdData, htmlData, savePath, attachmentsDir, articleTitle } = params
 
   const astTree = getAst(mdData)
   const linkList = getLinkList(astTree)
-  const videoLinkList = linkList.filter(link => /_lake_card.*?videoId/.test(link.node.url))
+  const videoLinkList = linkList.filter((link) =>
+    /_lake_card.*?videoId/.test(link.node.url),
+  )
   const audioLinkList = getAudioList(htmlData)
 
   // 无音视频
   if (videoLinkList.length === 0 && audioLinkList.length === 0) {
     return {
-      mdData
+      mdData,
     }
   }
 
   const spinner = ora({
     text: `下载 "${articleTitle}" 的音视频中...`,
-    stream: stdout
+    stream: stdout,
   })
-
 
   if (env.NODE_ENV !== 'test') {
     spinner.start()
@@ -62,29 +54,33 @@ export async function downloadVideo(params: IDownloadVideo) {
   try {
     // 类型 视频
     if (videoLinkList.length > 0) {
-      const realVideoList = await getRealVideoInfo(videoLinkList, params, attachmentsDirPath)
+      const realVideoList = await getRealVideoInfo(
+        videoLinkList,
+        params,
+        attachmentsDirPath,
+      )
       const promiseList = realVideoList.map((item) => {
         const dlFileParams = {
           fileUrl: item.videoInfo.video,
           savePath: item.currentFilePath,
-          token,
-          key,
-          fileName: item.videoInfo.name
+          fileName: item.videoInfo.name,
         }
         return downloadFile(dlFileParams)
       })
       const downloadFileInfo = await Promise.all(promiseList)
 
-      downloadFileInfo.forEach(info => {
-        const replaceInfo = realVideoList.find(item => item.videoInfo.video === info.fileUrl)
+      downloadFileInfo.forEach((info) => {
+        const replaceInfo = realVideoList.find(
+          (item) => item.videoInfo.video === info.fileUrl,
+        )
         if (replaceInfo) {
           // TODO: 这里直接更改了ast 还需考虑
           replaceInfo.astNode.node.url = `${attachmentsDir}${path.sep}${replaceInfo.fileName}`
           replaceInfo.astNode.node.children = [
             {
-              'type': 'text',
-              'value': `音视频附件: ${replaceInfo.videoInfo.name}`,
-            }
+              type: 'text',
+              value: `音视频附件: ${replaceInfo.videoInfo.name}`,
+            },
           ]
         }
       })
@@ -93,28 +89,32 @@ export async function downloadVideo(params: IDownloadVideo) {
 
     // 类型 音频
     if (audioLinkList.length > 0) {
-      const realVideoList = await getRealAudioInfo(audioLinkList, params, attachmentsDirPath)
+      const realVideoList = await getRealAudioInfo(
+        audioLinkList,
+        params,
+        attachmentsDirPath,
+      )
       const promiseList = realVideoList.map((item) => {
         const dlFileParams = {
           fileUrl: item.audioInfo.audio,
           savePath: item.currentFilePath,
-          token,
-          key,
-          fileName: item.audioInfo.fileName
+          fileName: item.audioInfo.fileName,
         }
         return downloadFile(dlFileParams)
       })
       const downloadFileInfo = await Promise.all(promiseList)
-      let audioMd = '\n\n> [yuque-dl warn]: 由于语雀markdown接口限制, 无法准确定位音频文件在文档中所在位置, 所以统一所有音频放到一起\n'
-      downloadFileInfo.forEach(info => {
-        const replaceInfo = realVideoList.find(item => item.audioInfo.audio === info.fileUrl)
+      let audioMd =
+        '\n\n> [yuque-dl warn]: 由于语雀markdown接口限制, 无法准确定位音频文件在文档中所在位置, 所以统一所有音频放到一起\n'
+      downloadFileInfo.forEach((info) => {
+        const replaceInfo = realVideoList.find(
+          (item) => item.audioInfo.audio === info.fileUrl,
+        )
         if (replaceInfo) {
           audioMd += `> - [音视频附件: ${replaceInfo.audioInfo.fileName}](${attachmentsDir}${path.sep}${replaceInfo.fileName})\n`
         }
       })
       resMdData += audioMd
     }
-
   } finally {
     spinnerStop()
   }
@@ -123,9 +123,8 @@ export async function downloadVideo(params: IDownloadVideo) {
     if (spinner) spinner.stop()
   }
   return {
-    mdData: resMdData
+    mdData: resMdData,
   }
-
 }
 
 // https://www.yuque.com/laoge776/ahq486/msa2ntf95o1646xw?_lake_card=%7B%22status%22%3A%22done%22%2C%22name%22%3A%22%E6%B5%8B%E8%AF%95%E7%94%A8%E8%A7%86%E9%A2%91.mp4%22%2C%22size%22%3A18058559%2C%22taskId%22%3A%22u0b9ed581-9b65-4f26-8a3d-6a583b056d3%22%2C%22taskType%22%3A%22upload%22%2C%22url%22%3Anull%2C%22cover%22%3Anull%2C%22videoId%22%3A%22inputs%2Fprod%2Fyuque%2F2024%2F43922322%2Fmp4%2F1723723211560-602e1f77-e869-4e89-9388-00d10e2fa782.mp4%22%2C%22download%22%3Afalse%2C%22__spacing%22%3A%22both%22%2C%22id%22%3A%22DuH55%22%2C%22margin%22%3A%7B%22top%22%3Atrue%2C%22bottom%22%3Atrue%7D%2C%22card%22%3A%22video%22%7D#DuH55
@@ -140,8 +139,8 @@ function perParseVideoInfo(url: string) {
     const dataStr = decodeURIComponent(encodeData)
     const data = JSON.parse(dataStr)
     return {
-      name: data?.name as string || '',
-      videoId: data?.videoId as string || ''
+      name: (data?.name as string) || '',
+      videoId: (data?.videoId as string) || '',
     }
   } catch (e) {
     return false
@@ -149,43 +148,43 @@ function perParseVideoInfo(url: string) {
 }
 
 interface IGetVideoApiParams {
-  videoId: string,
-  token?: string,
-  key?: string,
+  videoId: string
 }
 
 interface IGetVideoApiResponse {
   data: {
-    status: string,
+    status: string
     info: IGetVideoApiInfo
   }
 }
 interface IGetVideoApiInfo {
-  type: string,
-  cover?: string,
+  type: string
+  cover?: string
   // video 特有
-  video: string,
+  video: string
   // audio 特有
-  audio: string,
-  origin: string,
+  audio: string
+  origin: string
   state: number
 }
 
 function getVideoApi(params: IGetVideoApiParams) {
-  let apiUrl = 'https://www.yuque.com/api/video'
-  const { videoId, token, key } = params
+  const { videoId } = params
+  const { host } = globalConfig
+  let apiUrl = `${host}/api/video`
   const searchParams = new URLSearchParams()
   searchParams.set('video_id', videoId)
   apiUrl = `${apiUrl}?${searchParams.toString()}`
   return axios
-    .get<IGetVideoApiResponse>(apiUrl, genCommonOptions({token, key}))
-    .then(({data, status}) => {
+    .get<IGetVideoApiResponse>(apiUrl, genCommonOptions())
+    .then(({ data, status }) => {
       const res = data.data
       if (status === 200 && res.status === 'success') {
         return res.info
       }
       return false as const
-    }).catch(() => {
+    })
+    .catch(() => {
       // console.log(e)
       return false as const
     })
@@ -194,27 +193,25 @@ function getVideoApi(params: IGetVideoApiParams) {
 async function getRealVideoInfo(
   videoLinkList: ILinkItem[],
   downloadVideoParams: IDownloadVideo,
-  attachmentsDirPath: string
+  attachmentsDirPath: string,
 ) {
-  const {key, token} = downloadVideoParams
-  const parseVideoInfoPromiseList = videoLinkList.map(async link => {
+  const parseVideoInfoPromiseList = videoLinkList.map(async (link) => {
     const videoInfo = perParseVideoInfo(link.node.url)
     if (!videoInfo) return false
     const res = await getVideoApi({
       videoId: videoInfo.videoId,
-      key,
-      token
     })
     if (!res) return false
-    const fileName =  videoInfo.name ?? videoInfo.videoId.split('/').at(-1) ?? videoInfo.videoId
+    const fileName =
+      videoInfo.name ?? videoInfo.videoId.split('/').at(-1) ?? videoInfo.videoId
     return {
       videoInfo: {
         ...videoInfo,
-        ...res
+        ...res,
       },
       astNode: link,
       fileName,
-      currentFilePath: path.join(attachmentsDirPath, fileName)
+      currentFilePath: path.join(attachmentsDirPath, fileName),
     }
   })
   const parseVideoInfoList = await Promise.all(parseVideoInfoPromiseList)
@@ -222,17 +219,17 @@ async function getRealVideoInfo(
   return realVideoInfoList
 }
 
-type Truthy<T> = T extends false | '' | 0 | null | undefined ? never : T; // from lodash
+type Truthy<T> = T extends false | '' | 0 | null | undefined ? never : T // from lodash
 
 function truthy<T>(value: T): value is Truthy<T> {
   return !!value
 }
 
-interface IGetAudioItem{
-  status: string,
-  audioId: string,
-  fileName: string,
-  fileSize: number,
+interface IGetAudioItem {
+  status: string
+  audioId: string
+  fileName: string
+  fileSize: number
   id: string
 }
 
@@ -240,8 +237,8 @@ function getAudioList(htmlData: string): IGetAudioItem[] {
   const list = htmlData.match(audioReg) || []
   try {
     const audioList = list
-      .map(item => item.replace(audioReg, '$1'))
-      .map(item => JSON.parse(decodeURIComponent(item)))
+      .map((item) => item.replace(audioReg, '$1'))
+      .map((item) => JSON.parse(decodeURIComponent(item)))
     return audioList as IGetAudioItem[]
   } catch (e) {
     return []
@@ -251,25 +248,21 @@ function getAudioList(htmlData: string): IGetAudioItem[] {
 async function getRealAudioInfo(
   audioLinkList: IGetAudioItem[],
   downloadVideoParams: IDownloadVideo,
-  attachmentsDirPath: string
+  attachmentsDirPath: string,
 ) {
-  const {key, token} = downloadVideoParams
-  const parseVideoInfoPromiseList = audioLinkList.map(async audioItem => {
-
+  const parseVideoInfoPromiseList = audioLinkList.map(async (audioItem) => {
     const res = await getVideoApi({
       videoId: audioItem.audioId,
-      key,
-      token
     })
     if (!res) return false
     const fileName = audioItem?.fileName ?? audioItem.id
     return {
       audioInfo: {
         ...audioItem,
-        ...res
+        ...res,
       },
       fileName,
-      currentFilePath: path.join(attachmentsDirPath, fileName)
+      currentFilePath: path.join(attachmentsDirPath, fileName),
     }
   })
   const parseAudioInfoList = await Promise.all(parseVideoInfoPromiseList)

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import { ProgressBar, isValidUrl, logger } from './utils'
 import { downloadArticleList } from './download/list'
 
 import type { ICliOptions, IProgressItem } from './types'
+import { setConfig } from './config'
 
 export async function main(url: string, options: ICliOptions) {
   if (!isValidUrl(url)) {
@@ -19,16 +20,20 @@ export async function main(url: string, options: ICliOptions) {
     bookDesc,
     bookSlug,
     host,
-    imageServiceDomains
-  } = await getKnowledgeBaseInfo(url, {
-    token: options.token,
-    key: options.key
-  })
+    imageServiceDomains,
+  } = await getKnowledgeBaseInfo(url)
+  if (host) {
+    setConfig({ host })
+  }
+
   if (!bookId) throw new Error('No found book id')
   if (!tocList || tocList.length === 0) throw new Error('No found toc list')
-  const bookPath = path.resolve(options.distDir, bookName ? fixPath(bookName) : String(bookId))
+  const bookPath = path.resolve(
+    options.distDir,
+    bookName ? fixPath(bookName) : String(bookId),
+  )
 
-  await mkdir(bookPath, {recursive: true})
+  await mkdir(bookPath, { recursive: true })
 
   const total = tocList.length
   const progressBar = new ProgressBar(bookPath, total)
@@ -42,11 +47,8 @@ export async function main(url: string, options: ICliOptions) {
   const uuidMap = new Map<string, IProgressItem>()
   // 下载中断 重新获取下载进度数据
   if (progressBar.isDownloadInterrupted) {
-    progressBar.progressInfo.forEach(item => {
-      uuidMap.set(
-        item.toc.uuid,
-        item
-      )
+    progressBar.progressInfo.forEach((item) => {
+      uuidMap.set(item.toc.uuid, item)
     })
   }
   const articleUrlPrefix = url.replace(new RegExp(`(.*?/${bookSlug}).*`), '$1')
@@ -61,7 +63,7 @@ export async function main(url: string, options: ICliOptions) {
     progressBar,
     host,
     options,
-    imageServiceDomains
+    imageServiceDomains,
   })
 
   // 生成目录
@@ -69,7 +71,7 @@ export async function main(url: string, options: ICliOptions) {
     bookPath,
     bookName,
     bookDesc,
-    uuidMap
+    uuidMap,
   })
   await summary.genFile()
   logger.info(`√ 生成目录 ${path.resolve(bookPath, 'index.md')}`)

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -13,27 +13,44 @@ export interface ICliOptions {
   key?: string
   /** 是否忽略markdown中toc的生成 */
   toc: boolean
+  /** doc 类型导出格式 */
+  docExportType: DocExportType
+  /** board 类型导出格式 */
+  boardExportType: BoardExportType
+  /** table 类型导出格式 */
+  tableExportType: TableExportType
+  /** sheet 类型导出格式 */
+  sheetExportType: SheetExportType
+  /** 语雀开发授权码 */
+  ctoken?: string
 }
 
+export interface IConfig extends ICliOptions {
+  /** 语雀知识库url */
+  url: string
+  host: string
+}
 // ---------------- index
 
 export interface ArticleInfo {
-  bookId: number,
-  itemUrl: string,
-  savePath: string,
-  saveFilePath: string,
-  uuid: string,
-  articleTitle: string,
-  articleUrl: string,
-  ignoreImg: boolean,
-  host?: string,
+  bookId: number
+  itemUrl: string
+  savePath: string
+  saveFilePath: string
+  uuid: string
+  id?: number
+  articleTitle: string
+  articleUrl: string
+  ignoreImg: boolean
+  progressItem: Record<string, any>
+  host?: string
   imageServiceDomains: string[]
 }
 export interface DownloadArticleParams {
   /** 文章信息 */
-  articleInfo: ArticleInfo,
+  articleInfo: ArticleInfo
   /** 进度条实例 */
-  progressBar: ProgressBar,
+  progressBar: ProgressBar
   /** cli options */
   options: ICliOptions
 }
@@ -44,53 +61,50 @@ export interface IHandleMdDataOptions {
   articleUpdateTime: string
 }
 
-
 export interface IErrArticleInfo {
-  articleUrl: string,
-  errItem: IProgressItem,
-  errMsg: string,
+  articleUrl: string
+  errItem: IProgressItem
+  errMsg: string
   err: any
 }
 
 export interface IDownloadArticleListParams {
-  articleUrlPrefix: string,
-  total: number,
-  uuidMap: Map<string, IProgressItem>,
-  tocList: KnowledgeBase.Toc[],
-  bookPath: string,
-  bookId: number,
-  progressBar: ProgressBar,
+  articleUrlPrefix: string
+  total: number
+  uuidMap: Map<string, IProgressItem>
+  tocList: KnowledgeBase.Toc[]
+  bookPath: string
+  bookId: number
+  progressBar: ProgressBar
   host?: string
-  options: ICliOptions,
+  options: ICliOptions
   imageServiceDomains?: string[]
 }
 
 // ---------------- ProgressBar
 export interface IProgressItem {
-  path: string,
-  toc: KnowledgeBase.Toc,
-  pathIdList: string[],
+  path: string
+  toc: KnowledgeBase.Toc
+  pathIdList: string[]
   pathTitleList: string[]
 }
 export type IProgress = IProgressItem[]
 
-
 // ---------------- Summary
 export interface IGenSummaryFile {
-  bookPath: string,
-  bookName?: string,
-  bookDesc?: string,
+  bookPath: string
+  bookName?: string
+  bookDesc?: string
   uuidMap: Map<string, IProgressItem>
 }
 export interface SummaryItem {
-  id: string,
-  children?: SummaryItem[],
-  type: 'link' | 'title',
-  text: string,
-  level: number,
+  id: string
+  children?: SummaryItem[]
+  type: 'link' | 'title'
+  text: string
+  level: number
   link?: string
 }
-
 
 // ---------------- parseSheet
 
@@ -103,24 +117,24 @@ export interface SheetItemData {
 }
 
 export interface SheetItem {
-  name: string,
-  rowCount: number,
+  name: string
+  rowCount: number
   selections: {
-    row: number,
-    col: number,
-    rowCount: number,
-    colCount: number,
-    activeCol: number,
+    row: number
+    col: number
+    rowCount: number
+    colCount: number
+    activeCol: number
     activeRow: number
-  },
-  rows: any,
-  columns: any,
-  filter: any,
-  index: 0,
-  colCount: 26,
-  mergeCells: any,
-  id: string,
-  data: SheetItemData,
+  }
+  rows: any
+  columns: any
+  filter: any
+  index: 0
+  colCount: 26
+  mergeCells: any
+  id: string
+  data: SheetItemData
   vStore: any
 }
 
@@ -128,10 +142,10 @@ export interface SheetItem {
 export interface IKnowledgeBaseInfo {
   bookId?: number
   bookSlug?: string
-  tocList?: KnowledgeBase.Toc[],
-  bookName?: string,
-  bookDesc?: string,
-  host?: string,
+  tocList?: KnowledgeBase.Toc[]
+  bookName?: string
+  bookDesc?: string
+  host?: string
   imageServiceDomains?: string[]
 }
 export interface IReqHeader {
@@ -139,25 +153,66 @@ export interface IReqHeader {
 }
 export interface GetHeaderParams {
   /** token key */
-  key?:string,
+  key?: string
   /** token value */
   token?: string
+  /** referer  */
+  host: string
 }
-export type TGetKnowledgeBaseInfo = (url: string, headerParams: GetHeaderParams) => Promise<IKnowledgeBaseInfo>
+export type TGetKnowledgeBaseInfo = (url: string) => Promise<IKnowledgeBaseInfo>
 
 export interface GetMdDataParams {
-  articleUrl: string,
-  bookId: number,
+  articleUrl: string
+  bookId: number
   host?: string
-  token?: string,
+  token?: string
   key?: string
 }
+
+export enum DocExportType {
+  md = 'md',
+  lake = 'lake',
+  pdf = 'pdf',
+}
+
+export enum SheetExportType {
+  lakesheet = 'lakesheet',
+  xlsx = 'xlsx',
+}
+
+export enum BoardExportType {
+  lakeboard = 'lakeboard',
+  jpg = 'jpg',
+  png = 'png',
+}
+
+export enum MindExportType {
+  lakeboard = 'lakeboard',
+  jpg = 'jpg',
+  png = 'png',
+}
+
+export enum TableExportType {
+  laketable = 'laketable',
+  xlsx = 'xlsx',
+}
+
+export enum LakeType {
+  lake = 'lake',
+  lakeboard = 'lakeboard',
+  lakesheet = 'lakesheet',
+  laketable = 'laketable',
+}
+
 export interface IGetDocsMdDataRes {
-  apiUrl: string,
-  httpStatus: number,
+  apiUrl: string
+  httpStatus: number
   response?: ArticleResponse.RootObject
 }
-export type TGetMdData = (params: GetMdDataParams, isMd?: boolean) => Promise<IGetDocsMdDataRes>
+export type TGetMdData = (
+  params: GetMdDataParams,
+  isMd?: boolean,
+) => Promise<IGetDocsMdDataRes>
 
 export * from './ArticleResponse'
 export * from './KnowledgeBaseResponse'


### PR DESCRIPTION
1. 重构部分 options 传参，提供一个全局的 getConfig、setConfig 方法进行 cli 参数的读写，避免 key 和 token 在函数调用中多级传递
2. 增加 ctoken，boardExportType，sheetExportType，tableExportType，docExportType 的参数，并支持相应的下载导出逻辑
