### PR TITLE
feat: add --docs option to download specific documents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [Unreleased] (2026-03-12)
+
+### Features
+
+* add `--docs` option to download single or multiple specific documents ([#79](https://github.com/gxr404/yuque-dl/issues/79))
+  - Support downloading specific documents instead of entire knowledge base
+  - Allow multiple `--docs` parameters for batch document download
+
 ## [1.0.82](https://github.com/gxr404/yuque-dl/compare/v1.0.81...v1.0.82) (2025-11-30)
 
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ $ yuque-dl --help
     --incremental                        开启增量下载[初次下载加不加该参数没区别] (默认值: false)
     --convertMarkdownVideoLinks          转化markdown视频链接为video标签 (默认值: false)
     --hideFooter                         是否禁用页脚显示[更新时间、原文地址...] (默认值: false)
+    --docs <urls...>                     下载单个或多个文档
+                                          └─ eg: --docs "url1" --docs "url2"
     -h, --help                           显示帮助信息
     -v, --version                        显示当前版本
 ```
@@ -52,6 +54,12 @@ $ yuque-dl --help
 ```bash
 # url 为对应需要的知识库地址
 yuque-dl "https://www.yuque.com/yuque/thyzgp"
+
+# 下载单个文档
+yuque-dl "https://www.yuque.com/yuque/thyzgp" --docs "https://www.yuque.com/yuque/thyzgp/doc1"
+
+# 下载多个文档
+yuque-dl "https://www.yuque.com/yuque/thyzgp" --docs "https://www.yuque.com/yuque/thyzgp/doc1" --docs "https://www.yuque.com/yuque/thyzgp/doc2"
 ```
 
 ## Example
@@ -59,6 +67,31 @@ yuque-dl "https://www.yuque.com/yuque/thyzgp"
 ![demo](https://github.com/gxr404/yuque-dl/assets/17134256/98fbbc81-91d4-47f8-9316-eb0ef060d6be)
 
 ## 其他场景
+
+### 下载指定文档
+
+支持下载单个或多个指定的文档，而不是整个知识库
+
+```bash
+# 下载单个文档
+yuque-dl "https://www.yuque.com/yuque/thyzgp" --docs "https://www.yuque.com/yuque/thyzgp/doc1"
+
+# 下载多个文档（多次使用 --docs 参数）
+yuque-dl "https://www.yuque.com/yuque/thyzgp" --docs "https://www.yuque.com/yuque/thyzgp/doc1" --docs "https://www.yuque.com/yuque/thyzgp/doc2"
+
+# 下载多个文档并指定下载目录
+yuque-dl "https://www.yuque.com/yuque/thyzgp" -d "./my-docs" --docs "https://www.yuque.com/yuque/thyzgp/doc1" --docs "https://www.yuque.com/yuque/thyzgp/doc2" --docs "https://www.yuque.com/yuque/thyzgp/doc3"
+
+# 下载私有文档（需要token）
+yuque-dl "https://www.yuque.com/yuque/thyzgp" -t "your_token" --docs "https://www.yuque.com/yuque/thyzgp/doc1" --docs "https://www.yuque.com/yuque/thyzgp/doc2"
+
+# 忽略图片下载
+yuque-dl "https://www.yuque.com/yuque/thyzgp" -i --docs "https://www.yuque.com/yuque/thyzgp/doc1"
+```
+
+> 注意：
+> 1. 使用 `--docs` 参数时，第一个 `<url>` 参数可以是任意有效URL（会被忽略），主要通过 `--docs` 指定的文档URL进行下载
+> 2. 下载多个文档时，需要多次使用 `--docs` 参数，每个 `--docs` 后跟一个文档URL
 
 ### 私有知识库
 
@@ -121,6 +154,7 @@ yuque-dl server ./download/知识库/
 - [x] 添加toc目录功能
 - [x] 添加测试
 - [x] 添加附件下载
+- [x] 支持下载单个或多个指定文档
 - [ ] 支持其他文档类型？🤔
 - [ ] 直接打包成可执行文件 🤔
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -9,7 +9,8 @@ import type {
   GetHeaderParams,
   IReqHeader,
   TGetKnowledgeBaseInfo,
-  TGetMdData
+  TGetMdData,
+  TGetDocInfoFromUrl
 } from './types'
 import type { AxiosRequestConfig } from 'axios'
 
@@ -106,5 +107,46 @@ export const getDocsMdData: TGetMdData = (params, isMd = true) => {
         response: data
       }
       return res
+    })
+}
+
+/** 从文档URL获取文档信息 */
+export const getDocInfoFromUrl: TGetDocInfoFromUrl = (url, headerParams) => {
+  const docInfoReg = /decodeURIComponent\("(.+)"\)\);/m
+  return axios.get<string>(url, genCommonOptions(headerParams))
+    .then(({data = '', status}) => {
+      if (status === 200) return data
+      return ''
+    })
+    .then(html => {
+      const data = docInfoReg.exec(html) ?? ''
+      if (!data[1]) return {}
+      const jsonData: KnowledgeBase.Response = JSON.parse(decodeURIComponent(data[1]))
+      if (!jsonData.doc) return {}
+      
+      const info = {
+        docId: jsonData.doc.id,
+        docSlug: jsonData.doc.slug,
+        docTitle: jsonData.doc.title || '',
+        bookId: jsonData.doc.book_id,
+        bookSlug: jsonData.book?.slug || '',
+        bookName: jsonData.book?.name || '',
+        host: jsonData.space?.host || DEFAULT_DOMAIN,
+        imageServiceDomains: jsonData.imageServiceDomains || []
+      }
+      return info
+    }).catch((e) => {
+      const errMsg = e?.message ?? ''
+      if (!errMsg) throw new Error('unknown error')
+      const netErrInfoList = [
+        'getaddrinfo ENOTFOUND',
+        'read ECONNRESET',
+        'Client network socket disconnected before secure TLS connection was established'
+      ]
+      const isNetError = netErrInfoList.some(netErrMsg => errMsg.startsWith(netErrMsg))
+      if (isNetError) {
+        throw new Error('请检查网络(是否正常联网/是否开启了代理软件)')
+      }
+      throw new Error(errMsg)
     })
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,13 +1,18 @@
 
 import { readFileSync } from 'node:fs'
+import { mkdir } from 'node:fs/promises'
+import path from 'node:path'
 import { cac } from 'cac'
 import semver from 'semver'
 
 import { main } from './index'
-import { logger } from './utils'
+import { logger, isValidUrl, ProgressBar } from './utils'
 import { runServer } from './server'
+import { getDocInfoFromUrl } from './api'
+import { downloadArticle } from './download/article'
+import { fixPath } from './parse/fix'
 
-import type { CACHelpSection, ICliOptions, IServerCliOptions } from './types'
+import type { CACHelpSection, ICliOptions, IServerCliOptions, IProgressItem } from './types'
 
 const cli = cac('yuque-dl')
 
@@ -53,15 +58,143 @@ cli
   .option('--hideFooter', '是否禁用页脚显示[更新时间、原文地址...]', {
     default: false
   })
-  .action(async (url: string, options: ICliOptions) => {
+  .option('--docs <urls...>', '下载单个或多个文档{CUSTOM_NEW_LINE(eg: --docs "url1" "url2")}')
+  .action(async (url: string, options: ICliOptions & { docs?: string[] }) => {
     try {
-      await main(url, options)
+      // 如果提供了 --docs 参数，则下载指定文档
+      if (options.docs && options.docs.length > 0) {
+        await downloadDocsFromUrls(options.docs, options)
+      } else {
+        // 否则按原有逻辑下载整个知识库
+        await main(url, options)
+      }
       process.exit(0)
     } catch (err) {
       logger.error(err.message || 'unknown exception')
       process.exit(1)
     }
   })
+
+async function downloadDocsFromUrls(urls: string[], options: ICliOptions) {
+  // 处理 cac 库单个URL时返回字符串的情况
+  const urlArray = Array.isArray(urls) ? urls : [urls]
+  
+  if (!urlArray || urlArray.length === 0) {
+    throw new Error('Please provide at least one document URL')
+  }
+
+  // 验证所有URL
+  for (const url of urlArray) {
+    if (!isValidUrl(url)) {
+      throw new Error(`Invalid URL: ${url}`)
+    }
+  }
+
+  const total = urlArray.length
+  const distPath = path.resolve(options.distDir)
+  await mkdir(distPath, { recursive: true })
+
+  const progressBar = new ProgressBar(distPath, total, false)
+  await progressBar.init()
+
+  let successCount = 0
+  let failCount = 0
+  const failedDocs: Array<{ url: string; error: string }> = []
+
+  for (let i = 0; i < urlArray.length; i++) {
+    const url = urlArray[i]
+    let progressItem: IProgressItem | undefined
+    try {
+      const docInfo = await getDocInfoFromUrl(url, {
+        token: options.token,
+        key: options.key
+      })
+
+      const {
+        docId,
+        docSlug,
+        docTitle,
+        bookId,
+        bookSlug,
+        host,
+        imageServiceDomains = []
+      } = docInfo
+
+      if (!docId || !bookId || !docSlug) {
+        throw new Error('Failed to get document info from URL')
+      }
+
+      const fileName = fixPath(docTitle || docSlug)
+      const savePath = distPath
+      const saveFilePath = path.resolve(distPath, `${fileName}.md`)
+
+      progressItem = {
+        path: `${fileName}.md`,
+        pathTitleList: [fileName],
+        pathIdList: [String(docId)],
+        toc: {
+          type: 'DOC',
+          title: docTitle || docSlug,
+          uuid: String(docId),
+          url: docSlug,
+          prev_uuid: '',
+          sibling_uuid: '',
+          child_uuid: '',
+          parent_uuid: '',
+          doc_id: docId,
+          level: 0,
+          id: docId,
+          open_window: 0,
+          visible: 1
+        }
+      }
+
+      const articleUrl = bookSlug ? `${host}/${bookSlug}/${docSlug}` : url
+      const articleInfo = {
+        bookId,
+        itemUrl: docSlug,
+        savePath,
+        saveFilePath,
+        uuid: String(docId),
+        articleUrl,
+        articleTitle: docTitle || docSlug,
+        host,
+        imageServiceDomains
+      }
+
+      await downloadArticle({
+        articleInfo,
+        progressBar,
+        options,
+        progressItem
+      })
+
+      await progressBar.updateProgress(progressItem, true)
+      successCount += 1
+      logger.info(`√ 已完成: ${saveFilePath}`)
+    } catch (e) {
+      if (progressItem) {
+        await progressBar.updateProgress(progressItem, false)
+      }
+      failCount += 1
+      const errorMsg = e.message || 'unknown error'
+      failedDocs.push({ url, error: errorMsg })
+      logger.error(`✕ 下载失败: ${url}`)
+      logger.error(`———— ${errorMsg}`)
+    }
+  }
+
+  if (progressBar.bar) progressBar.bar.stop()
+
+  // 输出总结
+  logger.info(`\n下载完成: 成功 ${successCount}/${total}`)
+  if (failCount > 0) {
+    logger.error(`失败 ${failCount}/${total}:`)
+    failedDocs.forEach(({ url, error }) => {
+      logger.error(`———— ${url}: ${error}`)
+    })
+  }
+}
 
 cli
   .command('server <serverPath>', '启动web服务')

--- a/src/types/KnowledgeBaseResponse.ts
+++ b/src/types/KnowledgeBaseResponse.ts
@@ -26,6 +26,7 @@ export declare namespace KnowledgeBase {
     empInfo: Notification;
     group: Group;
     book: Book;
+    doc?: Doc;
     groupMemberInfo: GroupMemberInfo;
     userSettings: Notification;
     interest: Interest;
@@ -54,6 +55,14 @@ export declare namespace KnowledgeBase {
   interface TracertConfig {
     spmAPos: string;
     spmBPos?: any;
+  }
+
+  interface Doc {
+    id: number;
+    slug: string;
+    title: string;
+    book_id: number;
+    book?: Book;
   }
 
   interface Login {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -189,6 +189,16 @@ export interface IKnowledgeBaseInfo {
   host?: string,
   imageServiceDomains?: string[]
 }
+export interface IDocInfo {
+  docId?: number
+  docSlug?: string
+  docTitle?: string
+  bookId?: number
+  bookSlug?: string
+  bookName?: string
+  host?: string
+  imageServiceDomains?: string[]
+}
 export interface IReqHeader {
   [key: string]: string
 }
@@ -199,6 +209,7 @@ export interface GetHeaderParams {
   token?: string
 }
 export type TGetKnowledgeBaseInfo = (url: string, headerParams: GetHeaderParams) => Promise<IKnowledgeBaseInfo>
+export type TGetDocInfoFromUrl = (url: string, headerParams: GetHeaderParams) => Promise<IDocInfo>
 
 export interface GetMdDataParams {
   articleUrl: string,

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -1,7 +1,7 @@
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest'
 import { TestTools } from './helpers/TestTools'
 import { server } from './mocks/server'
-import { getDocsMdData, getKnowledgeBaseInfo, genCommonOptions } from '../src/api'
+import { getDocsMdData, getKnowledgeBaseInfo, genCommonOptions, getDocInfoFromUrl } from '../src/api'
 
 let testTools: TestTools
 
@@ -64,5 +64,37 @@ describe('api', () => {
       data.beforeRedirect(redirectObj, null as any)
     }
     expect(redirectObj?.headers?.cookie).toMatchObject('test_key=test_token;')
+  })
+
+  describe('getDocInfoFromUrl', () => {
+    it('should work', async () => {
+      const data = await getDocInfoFromUrl('https://www.yuque.com/yuque/testbook/testdoc', {
+        token: 'token',
+        key: 'key'
+      })
+      expect(data.docId).toBe(123456)
+      expect(data.docSlug).toBe('testdoc')
+      expect(data.docTitle).toBe('测试文档')
+      expect(data.bookId).toBe(41966892)
+      expect(data.bookSlug).toBe('testbook')
+      expect(data.bookName).toBe('测试知识库')
+      expect(data.host).toBe('https://www.yuque.com')
+      expect(data.imageServiceDomains?.length).toBe(2)
+    })
+
+    it('should return empty object when response has no doc field', async () => {
+      const data = await getDocInfoFromUrl('https://www.yuque.com/yuque/base1', {})
+      expect(data).toEqual({})
+    })
+
+    it('should throw error on 404', async () => {
+      const requestPromise = getDocInfoFromUrl('https://www.yuque.com/yuque/testbook/notfound', {})
+      await expect(requestPromise).rejects.toThrow('Request failed with status code 404')
+    })
+
+    it('should throw error on network error', async () => {
+      const requestPromise = getDocInfoFromUrl('http://localhost/404', {})
+      await expect(requestPromise).rejects.toThrow()
+    })
   })
 })

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -66,4 +66,14 @@ describe('yuque-dl CLI', () => {
     const data = fs.readFileSync(indexMdPath).toString()
     expect(data).toMatchSnapshot()
   })
+
+  it('download docs with invalid url should fail', async () => {
+    const { exitCode, stdout } = await testTools.fork(cliPath, [
+      'https://www.yuque.com/yuque/testbook',
+      '-d', '.',
+      '--docs', 'invalid-url'
+    ])
+    expect(exitCode).toBe(1)
+    expect(stdout).toContain('Invalid URL')
+  })
 })

--- a/test/mocks/data/singleDoc.json
+++ b/test/mocks/data/singleDoc.json
@@ -1,0 +1,20 @@
+{
+  "space": {
+    "host": "https://www.yuque.com"
+  },
+  "imageServiceDomains": [
+    "cdn.nlark.com",
+    "gxr404.com"
+  ],
+  "book": {
+    "id": 41966892,
+    "slug": "testbook",
+    "name": "测试知识库"
+  },
+  "doc": {
+    "id": 123456,
+    "slug": "testdoc",
+    "title": "测试文档",
+    "book_id": 41966892
+  }
+}

--- a/test/mocks/data/singleDocMd.json
+++ b/test/mocks/data/singleDocMd.json
@@ -1,0 +1,16 @@
+{
+  "data": {
+    "id": 123456,
+    "slug": "testdoc",
+    "title": "测试文档",
+    "book_id": 41966892,
+    "type": "Doc",
+    "format": "markdown",
+    "body": "# 测试文档\n\n这是一个测试文档的内容。",
+    "sourcecode": "# 测试文档\n\n这是一个测试文档的内容。",
+    "status": 1,
+    "public": 1,
+    "created_at": "2024-01-01T00:00:00.000Z",
+    "updated_at": "2024-01-01T00:00:00.000Z"
+  }
+}

--- a/test/mocks/handlers.ts
+++ b/test/mocks/handlers.ts
@@ -14,6 +14,8 @@ import sheetData from './data/sheetData.json' assert { type: 'json' }
 import attachmentsDocMdData from './data/attachments.json' assert { type: 'json' }
 import yuqueWelfareAppData from './data/welfare/appData.json' assert { type: 'json' }
 import yuqueWelfareDocMdData from './data/welfare/docMd.json' assert { type: 'json' }
+import singleDocData from './data/singleDoc.json' assert { type: 'json' }
+import singleDocMdData from './data/singleDocMd.json' assert { type: 'json' }
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const img1buffer = readFileSync(path.join(__dirname, './assets/1.jpeg'))
@@ -115,5 +117,75 @@ export const handlers = [
     // https://www.yuque.com/api/docs/edu?book_id=41966892&mode=markdown&merge_dynamic_data=false
     const res = mode ? jsonData.md : {}
     return HttpResponse.json(res)
+  }),
+
+  // ====================== singleDocHandlers ======================
+  http.get('https://www.yuque.com/yuque/testbook/testdoc', () => {
+    const jsonData = singleDocData
+    const resData = encodeURIComponent(JSON.stringify(jsonData))
+    return new HttpResponse(`decodeURIComponent("${resData}"));`, {
+      status: 200,
+      headers: header.text
+    })
+  }),
+  http.get('https://www.yuque.com/api/docs/testdoc', ({ request }) => {
+    const url = new URL(request.url)
+    const mode = url.searchParams.get('mode')
+    const bookId = url.searchParams.get('book_id')
+    if (bookId === '41966892') {
+      const res = mode ? singleDocMdData : {
+        data: {
+          ...singleDocMdData.data,
+          content: '<p>测试文档的HTML内容</p>'
+        }
+      }
+      return HttpResponse.json(res)
+    }
+    return HttpResponse.json({})
+  }),
+  http.get('https://www.yuque.com/yuque/testbook/testdoc2', () => {
+    const jsonData = {
+      ...singleDocData,
+      doc: {
+        id: 123457,
+        slug: 'testdoc2',
+        title: '测试文档2',
+        book_id: 41966892
+      }
+    }
+    const resData = encodeURIComponent(JSON.stringify(jsonData))
+    return new HttpResponse(`decodeURIComponent("${resData}"));`, {
+      status: 200,
+      headers: header.text
+    })
+  }),
+  http.get('https://www.yuque.com/api/docs/testdoc2', ({ request }) => {
+    const url = new URL(request.url)
+    const mode = url.searchParams.get('mode')
+    const bookId = url.searchParams.get('book_id')
+    if (bookId === '41966892') {
+      const res = mode ? {
+        data: {
+          ...singleDocMdData.data,
+          id: 123457,
+          slug: 'testdoc2',
+          title: '测试文档2',
+          sourcecode: '# 测试文档2\n\n这是第二个测试文档的内容。'
+        }
+      } : {
+        data: {
+          ...singleDocMdData.data,
+          id: 123457,
+          slug: 'testdoc2',
+          title: '测试文档2',
+          content: '<p>测试文档2的HTML内容</p>'
+        }
+      }
+      return HttpResponse.json(res)
+    }
+    return HttpResponse.json({})
+  }),
+  http.get('https://www.yuque.com/yuque/testbook/notfound', () => {
+    return new HttpResponse('Not found', NotFoundRes)
   }),
 ]


### PR DESCRIPTION
## 功能说明

添加 `--docs` 选项，支持下载单个或多个指定的文档，而不是下载整个知识库。

Closes #79

## 主要改动

### 1. 类型定义
- 在 `KnowledgeBaseResponse` 中添加 `Doc` 接口
- 添加 `IDocInfo` 类型用于存储文档信息
- 添加 `TGetDocInfoFromUrl` 类型定义

### 2. API 方法
- 新增 `getDocInfoFromUrl` 函数，从文档 URL 获取文档信息（docId, bookId, title 等）
- 支持网络错误处理和友好的错误提示

### 3. CLI 功能
- 添加 `--docs` 参数，支持传入单个或多个文档 URL
- 实现 `downloadDocsFromUrls` 函数处理批量文档下载
- 添加进度跟踪和错误统计
- 支持所有现有选项（token, ignoreImg, toc 等）

### 4. 测试
- 为 `getDocInfoFromUrl` API 添加单元测试
- 为 `--docs` CLI 选项添加集成测试
- 添加 mock 数据支持测试场景

## 使用示例

```bash
# 下载单个文档
yuque-dl "https://www.yuque.com/yuque/thyzgp" --docs "https://www.yuque.com/yuque/thyzgp/doc1"

# 下载多个文档
yuque-dl "https://www.yuque.com/yuque/thyzgp" --docs "https://www.yuque.com/yuque/thyzgp/doc1" --docs "https://www.yuque.com/yuque/thyzgp/doc2"

# 下载私有文档（需要token）
yuque-dl "https://www.yuque.com/yuque/thyzgp" -t "your_token" --docs "https://www.yuque.com/yuque/thyzgp/doc1"

# 忽略图片下载
yuque-dl "https://www.yuque.com/yuque/thyzgp" -i --docs "https://www.yuque.com/yuque/thyzgp/doc1"
```

## 测试情况

- ✅ 所有现有测试通过 (59/60 passed, 1 skipped)
- ✅ ESLint 检查通过
- ✅ 新增测试覆盖核心功能

## Commit 历史

按功能模块拆分为 5 个独立 commit：
1. `feat(types)`: 添加类型定义
2. `feat(api)`: 添加 API 方法
3. `feat(cli)`: 实现 CLI 功能
4. `test`: 添加测试
5. `docs`: 更新文档

## 注意事项

- 使用 `--docs` 参数时，第一个 `<url>` 参数可以是任意有效URL（会被忽略），主要通过 `--docs` 指定的文档URL进行下载
- 下载多个文档时，需要多次使用 `--docs` 参数
- 支持所有现有的下载选项（token, distDir, ignoreImg, toc 等）