### PR TITLE
feat: support downloading docs under a toc node

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,12 +23,15 @@ $ yuque-dl --help
     $ yuque-dl <url>
 
   Commands:
-    <url>                语雀知识库url
-    doc <...urls>        下载单个或多个文档
-    server <serverPath>  启动web服务
+    <url>                     语雀知识库url
+    doc <...urls>             下载单个或多个文档
+    node <bookUrl> <nodeUrl>  下载目录树节点下的文档
+    server <serverPath>       启动web服务
 
   For more info, run any command with the `--help` flag:
     $ yuque-dl --help
+    $ yuque-dl doc --help
+    $ yuque-dl node --help
     $ yuque-dl server --help
 
   Options:
@@ -66,6 +69,16 @@ yuque-dl doc "https://www.yuque.com/yuque/thyzgp/repository"
 # 下载多个文档
 yuque-dl doc "https://www.yuque.com/yuque/thyzgp/repository" "https://www.yuque.com/yuque/thyzgp/gbdfpb"
 ```
+
+下载知识库目录树中某个节点下的文档
+
+```bash
+# bookUrl 为知识库地址，nodeUrl 为目录树中某个文档节点地址
+yuque-dl node "https://www.yuque.com/yuque/thyzgp" "https://www.yuque.com/yuque/thyzgp/repository"
+```
+
+> [!NOTE]
+> `nodeUrl` 当前通过 URL 最后一段 slug 匹配目录树节点，支持有 URL 的文档节点；纯目录标题节点如果没有文档 URL，暂不支持直接定位。
 
 ## Example
 
@@ -135,6 +148,7 @@ yuque-dl server ./download/知识库/
 - [x] 添加测试
 - [x] 添加附件下载
 - [x] 支持下载单个或多个指定文档
+- [x] 支持下载目录树节点下的多个文档
 - [ ] 支持其他文档类型？🤔
 - [ ] 直接打包成可执行文件 🤔
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,7 +3,7 @@ import { readFileSync } from 'node:fs'
 import { cac, Command } from 'cac'
 import semver from 'semver'
 
-import { downloadDocsFromUrls, main } from './index'
+import { downloadDocsFromUrls, downloadNodeFromUrl, main } from './index'
 import { logger } from './utils'
 import { runServer } from './server'
 
@@ -73,6 +73,19 @@ addCommonOption(docCommand)
   .action(async (urls: string[], options: ICliOptions) => {
     try {
       await downloadDocsFromUrls(urls, options)
+      process.exit(0)
+    } catch (err) {
+      logger.error(err.message || 'unknown exception')
+      process.exit(1)
+    }
+  })
+
+// 子命令 node 下载指定目录树节点下的文档
+const nodeCommand = cli.command('node <bookUrl> <nodeUrl>', '下载目录树节点下的文档')
+addCommonOption(nodeCommand)
+  .action(async (bookUrl: string, nodeUrl: string, options: ICliOptions) => {
+    try {
+      await downloadNodeFromUrl(bookUrl, nodeUrl, options)
       process.exit(0)
     } catch (err) {
       logger.error(err.message || 'unknown exception')

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import { downloadArticleList } from './download/list'
 
 import type { ICliOptions, IProgressItem } from './types'
 import { downloadArticle } from './download/article'
+import type { KnowledgeBase } from './types'
 
 export async function main(url: string, options: ICliOptions) {
   if (!isValidUrl(url)) {
@@ -81,6 +82,128 @@ export async function main(url: string, options: ICliOptions) {
   if (progressBar.curr === total) {
     logger.info(`√ 已完成: ${bookPath}`)
   }
+}
+
+export async function downloadNodeFromUrl(bookUrl: string, nodeUrl: string, options: ICliOptions) {
+  if (!isValidUrl(bookUrl)) {
+    throw new Error('Please enter a valid URL')
+  }
+  if (!isValidUrl(nodeUrl)) {
+    throw new Error(`Invalid URL: ${nodeUrl}`)
+  }
+
+  const {
+    bookId,
+    tocList,
+    bookName,
+    bookDesc,
+    bookSlug,
+    host,
+    imageServiceDomains
+  } = await getKnowledgeBaseInfo(bookUrl, {
+    token: options.token,
+    key: options.key
+  })
+  if (!bookId) throw new Error('No found book id')
+  if (!bookSlug) throw new Error('No found book slug')
+  if (!tocList || tocList.length === 0) throw new Error('No found toc list')
+
+  const nodeSlug = getUrlSlug(nodeUrl)
+  if (!nodeSlug) {
+    throw new Error(`No found node in toc list: ${nodeUrl}`)
+  }
+
+  const targetToc = tocList.find(item => item.url === nodeSlug)
+  if (!targetToc) {
+    throw new Error(`No found node in toc list: ${nodeSlug}`)
+  }
+
+  const nodeTocList = filterNodeTocList(tocList, targetToc)
+  const nodeUuidSet = new Set(nodeTocList.map(item => item.uuid))
+  const bookPath = path.resolve(options.distDir, bookName ? fixPath(bookName) : String(bookId))
+
+  await mkdir(bookPath, {recursive: true})
+
+  const total = nodeTocList.length
+  const progressBar = new ProgressBar(bookPath, total, options.incremental, false, nodeUuidSet)
+  await progressBar.init()
+
+  if (!options.incremental && progressBar.curr == total) {
+    if (progressBar.bar) progressBar.bar.stop()
+    logger.info(`√ 已完成: ${bookPath}`)
+    return
+  }
+
+  const uuidMap = new Map<string, IProgressItem>()
+  if (progressBar.isDownloadInterrupted || options.incremental) {
+    progressBar.progressInfo.forEach(item => {
+      uuidMap.set(
+        item.toc.uuid,
+        item
+      )
+    })
+  }
+  const articleUrlPrefix = bookUrl.replace(new RegExp(`(.*?/${bookSlug}).*`), '$1')
+
+  await downloadArticleList({
+    articleUrlPrefix,
+    total,
+    uuidMap,
+    tocList: nodeTocList,
+    bookPath,
+    bookId,
+    progressBar,
+    host,
+    options,
+    imageServiceDomains
+  })
+
+  const summary = new Summary({
+    bookPath,
+    bookName,
+    bookDesc,
+    uuidMap
+  })
+  await summary.genFile()
+  logger.info(`√ 生成目录 ${path.resolve(bookPath, 'index.md')}`)
+
+  if (progressBar.curr === total) {
+    logger.info(`√ 已完成: ${bookPath}`)
+  }
+}
+
+function getUrlSlug(url: string) {
+  const { pathname } = new URL(url)
+  const pathList = pathname.split('/').filter(Boolean)
+  const slug = pathList[pathList.length - 1]
+  return slug ? decodeURIComponent(slug) : ''
+}
+
+function filterNodeTocList(tocList: KnowledgeBase.Toc[], targetToc: KnowledgeBase.Toc) {
+  const tocMap = new Map(tocList.map(toc => [toc.uuid, toc]))
+  return tocList
+    .filter(item => {
+      return item.uuid === targetToc.uuid || isAncestorOrDescendantToc(tocMap, item, targetToc)
+    })
+}
+
+function isAncestorOrDescendantToc(
+  tocMap: Map<string, KnowledgeBase.Toc>,
+  item: KnowledgeBase.Toc,
+  targetToc: KnowledgeBase.Toc
+) {
+  let parentUuid = item.parent_uuid
+  while (parentUuid) {
+    if (parentUuid === targetToc.uuid) return true
+    parentUuid = tocMap.get(parentUuid)?.parent_uuid || ''
+  }
+
+  parentUuid = targetToc.parent_uuid
+  while (parentUuid) {
+    if (parentUuid === item.uuid) return true
+    parentUuid = tocMap.get(parentUuid)?.parent_uuid || ''
+  }
+  return false
 }
 
 

--- a/src/utils/ProgressBar.ts
+++ b/src/utils/ProgressBar.ts
@@ -16,17 +16,23 @@ export class ProgressBar {
   incremental: boolean
   // 是否禁用 process.json 单文档下载时禁用
   disableProgressJSON: boolean
+  scopeUuidSet?: Set<string>
+  private persistedProgressInfo: IProgress = []
 
-  constructor (bookPath: string, total: number, incremental = false, disableProgressJSON = false) {
+  constructor (bookPath: string, total: number, incremental = false, disableProgressJSON = false, scopeUuidSet?: Set<string>) {
     this.bookPath = bookPath
     this.progressFilePath = `${bookPath}/progress.json`
     this.total = total
     this.incremental = incremental
     this.disableProgressJSON = disableProgressJSON
+    this.scopeUuidSet = scopeUuidSet
   }
 
   async init() {
-    this.progressInfo = this.disableProgressJSON ? [] : await this.getProgress()
+    this.persistedProgressInfo = this.disableProgressJSON ? [] : await this.getProgress()
+    this.progressInfo = this.scopeUuidSet
+      ? this.persistedProgressInfo.filter(item => this.scopeUuidSet!.has(item.toc.uuid))
+      : this.persistedProgressInfo
     // 增量下载需把进度重置为0 然后每一篇文档重新检查一遍 update时间
     this.curr = this.incremental ? 0 : this.progressInfo.length
     // 可能出现增量下载
@@ -75,11 +81,15 @@ export class ProgressBar {
         this.progressInfo.push(progressItem)
       }
       if (!this.disableProgressJSON) {
+        const writeProgressInfo = this.scopeUuidSet
+          ? this.mergeScopedProgressInfo()
+          : this.progressInfo
         await fs.writeFile(
           this.progressFilePath,
-          JSON.stringify(this.progressInfo),
+          JSON.stringify(writeProgressInfo),
           {encoding: 'utf8'}
         )
+        this.persistedProgressInfo = writeProgressInfo
       }
     }
     if (this.bar) {
@@ -89,6 +99,28 @@ export class ProgressBar {
         console.log('')
       }
     }
+  }
+
+  private mergeScopedProgressInfo(): IProgress {
+    if (!this.scopeUuidSet) return this.progressInfo
+    const scopedProgressMap = new Map(
+      this.progressInfo.map(item => [item.toc.uuid, item])
+    )
+    const mergedProgressInfo: IProgress = []
+
+    this.persistedProgressInfo.forEach(item => {
+      const progressItem = scopedProgressMap.get(item.toc.uuid)
+      if (progressItem) {
+        mergedProgressInfo.push(progressItem)
+        scopedProgressMap.delete(item.toc.uuid)
+      } else if (!this.scopeUuidSet!.has(item.toc.uuid)) {
+        mergedProgressInfo.push(item)
+      }
+    })
+    scopedProgressMap.forEach(item => {
+      mergedProgressInfo.push(item)
+    })
+    return mergedProgressInfo
   }
   // 暂停进度条的打印
   pause () {

--- a/test/__snapshots__/index.test.ts.snap
+++ b/test/__snapshots__/index.test.ts.snap
@@ -1,5 +1,45 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`main > download node subtree should work 1`] = `
+"# Target
+
+# DOC1
+![](https://gxr404.com/1.jpeg)
+## SubTitle
+![](https://gxr404.com/2.jpeg)
+
+> 更新: 2025-03-12 20:59:27  
+> 原文: <https://www.yuque.com/yuque/node-test/one>"
+`;
+
+exports[`main > download node subtree should work 2`] = `
+"# Child
+
+# DOC2
+## Title
+text...
+### Title2
+text...
+
+
+> 原文: <https://www.yuque.com/yuque/node-test/two>"
+`;
+
+exports[`main > download node subtree should work 3`] = `
+"# 节点下载测试
+
+> node test desc
+
+
+## Root
+
+
+### [Target](Root/Target/index.md)
+
+- [Child](Root/Target/Child.md)
+"
+`;
+
 exports[`main > should work 1`] = `
 "# 知识库TEST1
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,8 +1,9 @@
 import path from 'node:path'
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest'
+import { http, HttpResponse } from 'msw'
 import { TestTools } from './helpers/TestTools'
 import { server } from './mocks/server'
-import { main } from '../src/index'
+import { downloadNodeFromUrl, main } from '../src/index'
 import { readdirSync, readFileSync } from 'node:fs'
 
 
@@ -45,5 +46,94 @@ describe('main', () => {
     expect(readFileSync(img1).length).toBe(99892)
     const img2 = path.join(testTools.cwd, `知识库TEST1/Title1/img/002/${imgList[1]}`)
     expect(readFileSync(img2).length).toBe(81011)
+  })
+
+  it('download node subtree should work', async () => {
+    server.use(
+      http.get('https://www.yuque.com/yuque/node-test', () => {
+        const jsonData = {
+          space: {
+            host: 'https://www.yuque.com'
+          },
+          book: {
+            id: 41966892,
+            slug: 'node-test',
+            name: '节点下载测试',
+            description: 'node test desc',
+            toc: [
+              {
+                type: 'TITLE',
+                title: 'Root',
+                uuid: '001',
+                child_uuid: '002',
+                parent_uuid: ''
+              },
+              {
+                type: 'DOC',
+                title: 'Target',
+                uuid: '002',
+                url: 'one',
+                child_uuid: '003',
+                parent_uuid: '001'
+              },
+              {
+                type: 'DOC',
+                title: 'Child',
+                uuid: '003',
+                url: 'two',
+                child_uuid: '',
+                parent_uuid: '002'
+              },
+              {
+                type: 'DOC',
+                title: 'Sibling',
+                uuid: '004',
+                url: 'two',
+                child_uuid: '',
+                parent_uuid: '001'
+              }
+            ]
+          },
+          imageServiceDomains: [
+            'gxr404.com'
+          ]
+        }
+        const resData = encodeURIComponent(JSON.stringify(jsonData))
+        return new HttpResponse(`decodeURIComponent("${resData}"));`, {
+          status: 200,
+          headers: {
+            'Content-Type': 'text/html'
+          }
+        })
+      })
+    )
+
+    await downloadNodeFromUrl(
+      'https://www.yuque.com/yuque/node-test',
+      'https://www.yuque.com/yuque/node-test/one',
+      {
+        distDir: testTools.cwd,
+        ignoreImg: true,
+        toc: false
+      } as any
+    )
+
+    const bookPath = path.join(testTools.cwd, '节点下载测试')
+    expect(readFileSync(path.join(bookPath, 'Root/Target/index.md')).toString()).toMatchSnapshot()
+    expect(readFileSync(path.join(bookPath, 'Root/Target/Child.md')).toString()).toMatchSnapshot()
+    expect(readFileSync(path.join(bookPath, 'index.md')).toString()).toMatchSnapshot()
+    expect(() => readFileSync(path.join(bookPath, 'Root/Sibling.md'))).toThrow()
+  })
+
+  it('download node subtree should fail when node url is not in toc', async () => {
+    await expect(downloadNodeFromUrl(
+      'https://www.yuque.com/yuque/base1',
+      'https://www.yuque.com/yuque/base1/not-found',
+      {
+        distDir: testTools.cwd,
+        ignoreImg: true,
+        toc: false
+      } as any
+    )).rejects.toThrow('No found node in toc list: not-found')
   })
 })

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -185,4 +185,28 @@ describe('ProgressBar', () => {
     // toc.uuid一致 则是 更新 而非 push
     expect(pr.curr).toBe(1)
   })
+
+  it('scoped progress should preserve other progress items', async() => {
+    let pr = new ProgressBar(testTools.cwd, 3)
+    await pr.init()
+    await pr.updateProgress(updateItem, true)
+    await pr.updateProgress(updateItem2, true)
+    await pr.updateProgress(updateItem3, true)
+
+    const scopedItem = {
+      ...updateItem2,
+      path: '语雀知识库2/index.md',
+    }
+    pr = new ProgressBar(testTools.cwd, 1, false, false, new Set([updateItem2.toc.uuid]))
+    await pr.init()
+    expect(pr.curr).toBe(1)
+    expect(pr.progressInfo).toMatchObject([updateItem2])
+
+    pr = new ProgressBar(testTools.cwd, 1, true, false, new Set([updateItem2.toc.uuid]))
+    await pr.init()
+    await pr.updateProgress(scopedItem, true)
+
+    const prInfo = await pr.getProgress()
+    expect(prInfo).toMatchObject([updateItem, scopedItem, updateItem3])
+  })
 })


### PR DESCRIPTION
## 这个 PR 做了什么

  这个 PR 新增了一个命令，用来下载语雀知识库目录树里某个节点下面的所有文档：

  ```bash
  yuque-dl node <知识库地址> <节点文档地址>
 ```

  之前已有能力是：

  - 下载整个知识库
  - 下载一个或多个指定文档

  但如果只想下载某个目录/节点下面的一组文档，就需要手动一个个传文档 URL。这个 PR 补上了这个场景。

  ## 主要改动

  - 新增 yuque-dl node <bookUrl> <nodeUrl> 命令
  - 根据 nodeUrl 在知识库目录树里找到对应节点
  - 只下载该节点以及它下面的子文档
  - 本地文件仍然保留原来的目录层级
  - 复用原有文档下载、图片/附件处理、目录生成逻辑
  - 调整 progress.json 处理，避免局部下载和全量下载的进度互相影响
  - 增加了相关测试
  - 更新 README 使用说明

  ## 当前限制

  目前 nodeUrl 是通过 URL 最后一段 slug 匹配目录节点的，所以支持的是“有文档 URL 的节点”。

  如果是纯目录标题节点，没有对应文档 URL，当前还不能直接通过这个命令定位。

  ## 测试

  已执行：

  pnpm vitest --run test/index.test.ts test/utils.test.ts
  pnpm run build

  说明：项目里原本的完整 pnpm test 包含 CLI 子进程测试，这些测试会真实请求语雀网络，在网络受限环境下可能失败，和本次改动无关。

 ## Summary

  This introduces a new command:

  ```bash
  yuque-dl node <bookUrl> <nodeUrl>
```

  It is useful when users want to download part of a knowledge base by selecting a node in the directory tree, instead of
  downloading the entire book or manually listing multiple document URLs.

  ## Changes

  - Add downloadNodeFromUrl to resolve a target node from nodeUrl and download that node's subtree.
  - Add node <bookUrl> <nodeUrl> CLI command.
  - Reuse the existing article download and summary generation flow.
  - Preserve the full directory path for downloaded subtree files.
  - Scope progress tracking by node UUIDs to avoid conflicts with existing full-book progress.
  - Add tests for subtree download and scoped progress merging.
  - Update README with usage and current limitation.

  ## Limitation

  nodeUrl is currently resolved by matching the last URL slug against toc.url, so this supports document nodes with URLs. Pure
  title nodes without document URLs are not directly supported yet.

  ## Test

  pnpm vitest --run test/index.test.ts test/utils.test.ts
  pnpm run build

  Note: the existing full pnpm test suite still includes CLI subprocess tests that make real network requests and may fail in
  network-restricted environments.