### PR TITLE
fix: 修复md链接内半角括号导致跳转失效问题

### DIFF
--- a/src/parse/Summary.ts
+++ b/src/parse/Summary.ts
@@ -22,7 +22,11 @@ export default class Summary {
       const parentId = toc['parent_uuid']
       const findRes = this.findTree(summary, parentId)
       const dirNameReg = /[\\/:*?"<>|\n\r]/g
-      const tocText = toc.title.replace(dirNameReg, '_').replace(/\s/, '')
+      const tocText = toc.title
+        .replace(dirNameReg, '_')
+        .replace(/\s/, '')
+        .replace(/\(/g, '（')
+        .replace(/\)/g, '）')
       const item: SummaryItem = {
         text: tocText,
         id: toc.uuid,
@@ -85,13 +89,13 @@ export default class Summary {
       if (item.type === ARTICLE_TOC_TYPE.TITLE) {
         // 是标题同时也是文档的情况
         if (item.link) {
-          const link = item.link ? item.link.replace(/\s/g, '%20') : item.link
+          const link = this.formatLink(item.link)
           summaryContent += `\n${''.padStart(item.level + 1, '#')} [${item.text}](${link})\n\n`
         } else {
           summaryContent += `\n${''.padStart(item.level + 1, '#')} ${item.text}\n\n`
         }
       } else if (item.type === ARTICLE_TOC_TYPE.LINK) {
-        const link = item.link ? item.link.replace(/\s/g, '%20') : item.link
+        const link = this.formatLink(item.link)
         summaryContent += `${item.level === 1 ? '\n##' : '-'} [${item.text}](${link})\n`
       }
       if (Array.isArray(item.children)) {
@@ -99,6 +103,14 @@ export default class Summary {
       }
     }
     return summaryContent
+  }
+
+  formatLink(rawLink?: string): string {
+    if (!rawLink) return ''
+    return rawLink
+      .replace(/\s/g, '%20')
+      .replace(/\(/g, '（')
+      .replace(/\)/g, '）')
   }
 
   findIdItem(node: SummaryItem, id: string) {

--- a/src/parse/fix.ts
+++ b/src/parse/fix.ts
@@ -82,7 +82,13 @@ export function fixMarkdownImage(imgList: string[], mdData: string, htmlData: st
 export function fixPath(dirPath: string) {
   if (!dirPath) return ''
   const dirNameReg = /[\\/:*?"<>|\n\r]/g
-  return removeEmojis(dirPath.replace(dirNameReg, '_').replace(/\s/g, ''))
+  return removeEmojis(
+    dirPath
+      .replace(dirNameReg, '_')
+      .replace(/\s/g, '')
+      .replace(/\(/g, '（')
+      .replace(/\)/g, '）')
+  )
 }
 
 


### PR DESCRIPTION
处理markdown链接中半角括号破坏链接解析，造成文档跳转失败；
对目录及跳转链接中的半角括号调整为圆角括号；
为什么不用<linkUrl>，因为这种场景下md压缩包上传语雀后，语雀无法识别